### PR TITLE
Fix DeviceInfo: Returning wrong device name

### DIFF
--- a/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
+++ b/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs
@@ -112,6 +112,13 @@ namespace Xamarin.Essentials
         }
 
         static string GetSystemSetting(string name)
-           => Settings.System.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+        {
+            // DEVICE_NAME added in System.Global in API level 25
+            // https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
+            if (Essentials.Platform.HasApiLevelNMr1)
+                return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+            else
+                return Settings.System.GetString(Essentials.Platform.AppContext.ContentResolver, name);
+        }
     }
 }


### PR DESCRIPTION
DeviceInfo API was returning device model as a device name.

Description of Change
Describe your changes here.

Bugs Fixed
Related to issue #
#1417

API Changes
DeviceInfo

Added:

if (Essentials.Platform.HasApiLevelNMr1)
return Settings.Global.GetString(Essentials.Platform.AppContext.ContentResolver, name);

Behavioral Changes
Now user will get correct device name if device OS version is 7.1 or later